### PR TITLE
Login logo configurable

### DIFF
--- a/src/main/kotlin/au/org/ala/cas/AlaCasProperties.kt
+++ b/src/main/kotlin/au/org/ala/cas/AlaCasProperties.kt
@@ -59,6 +59,7 @@ open class SkinProperties {
     lateinit var orgShortName: String
     lateinit var orgLongName: String
     lateinit var orgNameKey: String
+    lateinit var loginLogo: String
     var cacheDuration: String = "PT30m"
     var uiVersion: Int = 2
 }

--- a/src/main/kotlin/au/org/ala/cas/thymeleaf/AlaCasThemesConfiguration.kt
+++ b/src/main/kotlin/au/org/ala/cas/thymeleaf/AlaCasThemesConfiguration.kt
@@ -46,6 +46,7 @@ class AlaCasThemesConfiguration {
         const val CREATE_ACCOUNT_URL = "createAccountUrl"
         const val ALA_UI_VERSION = "alaUiVersion"
         const val ALA_PROPERTIES = "ala"
+        const val LOGIN_LOGO = "loginLogo"
 
         val log = logger()
 
@@ -65,6 +66,7 @@ class AlaCasThemesConfiguration {
                 RESET_PASSWORD_URL to alaCasProperties.skin.resetPasswordUrl,
                 CREATE_ACCOUNT_URL to alaCasProperties.skin.createAccountUrl,
                 ALA_UI_VERSION to "ala-ui-${alaCasProperties.skin.uiVersion}",
+                LOGIN_LOGO to alaCasProperties.skin.loginLogo,
                 ALA_PROPERTIES to alaCasProperties
             ).forEach(thymeleafViewResolver::addStaticVariable)
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -395,6 +395,7 @@ ala:
     termsUrl: ${ala.skin.baseUrl}terms-of-use/
     headerFooterUrl: ${ala.skin.baseUrl}commonui-bs3/
     favIconBaseUrl: ${ala.skin.baseUrl}wp-content/themes/ala-wordpress-theme/img/favicon/
+    loginLogo: images/supporting-graphic-element-flat-medium.png
     bieBaseUrl: https://bie.ala.org.au/
     bieSearchPath: search
     userDetailsUrl: ${ala.userDetailsBaseUrl}

--- a/src/main/resources/templates/fragments/loginform.html
+++ b/src/main/resources/templates/fragments/loginform.html
@@ -19,7 +19,7 @@
                         <div class="col-xs-12">
                             <div class="logo-brand">
                                 <div class="brand-layout-control">
-                                    <img alt="Brand" class="img-responsive" th:src="@{images/supporting-graphic-element-flat-medium.png}" />
+                                    <img alt="Brand" class="img-responsive" th:src="@{${loginLogo}}" />
                                 </div>
                                 <h2 class="heading-medium-large" th:text="#{ala.screen.login.instructions(${orgShortName})}">Sign in to the ALA</h2>
                                 <p class="small" th:if="${termsUrl}"><span th:text="#{ala.screen.login.terms.prefix}" th:remove="tag">By using this site you agree to our</span> <a th:href="${termsUrl}" th:text="#{ala.screen.login.terms.link}">Terms of Use</a></p>


### PR DESCRIPTION
This PR adds a new configuration variable `loginLogo` to allow the customization of this image in CAS login.

Tested in: https://auth.l-a.site/cas/login but with `5.3.12-1` because it seems that some variables are missing in my environment (and ala-install) to run a more recent CAS version without errors (I get like `hiOrgServer` missing var exceptions).

cc @jloomisVCE