### PR TITLE
CAS upgrade

### DIFF
--- a/UPGRADE.MD
+++ b/UPGRADE.MD
@@ -1,3 +1,10 @@
+Upgrade notes from CAS 6.5.6-2 to 6.6.5-1
+====================================
+
+1. "CAS" service entries need to updated from class RegexRegisteredService to CasApplicationService:
+```json
+db.services.update({_class: 'org.apereo.cas.services.RegexRegisteredService'}, {'$set': { '_class': 'org.apereo.cas.services.CasRegisteredService' } });
+```
 Upgrade notes from CAS 6.5.6-1 to 6.5.6-2
 ====================================
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>cas</artifactId>
     <packaging>war</packaging>
     <!-- Version should ${cas.version}-${ala.build.version}(-SNAPSHOT)? -->
-    <version>6.5.9-1-SNAPSHOT</version>
+    <version>6.6.5-1-SNAPSHOT</version>
 
     <name>ALA CAS</name>
     <description>ALA Central Authentication Service</description>
@@ -196,14 +196,30 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-<!--            <plugin>-->
-<!--                <artifactId>maven-surefire-plugin</artifactId>-->
-<!--                <version>3.0.0-M5</version>-->
-<!--&lt;!&ndash;                <version>2.22.1</version>&ndash;&gt;-->
-<!--                <configuration>-->
-<!--                    <jvm>${env.JAVA_HOME}/bin/java</jvm>-->
-<!--                </configuration>-->
-<!--            </plugin>-->
+            <!-- override enforcer enforce-bytecode-version config to exclude org.mongodb:bson-record-codec because
+                 it's only loaded when java records are encountered -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-bytecode-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <enforceBytecodeVersion>
+                                    <excludes>
+                                        <exclude>org.mongodb:bson-record-codec</exclude>
+                                    </excludes>
+                                </enforceBytecodeVersion>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <finalName>cas</finalName>
     </build>
@@ -631,6 +647,12 @@
         </dependency>
         <dependency>
             <groupId>org.apereo.cas</groupId>
+            <artifactId>cas-server-core-validation-api</artifactId>
+            <version>${cas.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apereo.cas</groupId>
             <artifactId>cas-server-core-util</artifactId>
             <version>${cas.version}</version>
             <scope>compile</scope>
@@ -831,7 +853,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20210307</version>
+            <version>20220320</version>
         </dependency>
         <dependency>
             <groupId>org.apereo.cas</groupId>
@@ -858,22 +880,22 @@
         <dependency>
             <groupId>org.springframework.session</groupId>
             <artifactId>spring-session-data-mongodb</artifactId>
-            <version>2.6.3</version>
+            <version>2.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.session</groupId>
             <artifactId>spring-session-core</artifactId>
-            <version>2.6.3</version>
+            <version>2.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-mongodb</artifactId>
-            <version>3.3.5</version>
+            <version>3.4.8</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.session</groupId>
             <artifactId>spring-session-data-redis</artifactId>
-            <version>2.6.3</version>
+            <version>2.7.0</version>
         </dependency>
 
         <!-- Lombok for the CAS sources -->
@@ -900,8 +922,8 @@
     </dependencies>
 
     <properties>
-        <cas.version>6.5.9</cas.version>
-        <springboot.version>2.6.3</springboot.version>
+        <cas.version>6.6.5</cas.version>
+        <springboot.version>2.7.3</springboot.version>
         <!-- app.server could be -jetty, -undertow, -tomcat, or blank if you plan to provide appserver -->
         <!-- we use blank to create a blank war and spring boot repackage to build an executable Tomcat jar -->
         <app.server></app.server>

--- a/src/main/kotlin/au/org/ala/cas/AlaCasProperties.kt
+++ b/src/main/kotlin/au/org/ala/cas/AlaCasProperties.kt
@@ -11,7 +11,8 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty
 open class AlaCasProperties(
     @field:NestedConfigurationProperty var cookie: AlaAuthCookieProperties = AlaAuthCookieProperties(),
     @field:NestedConfigurationProperty var userCreator: UserCreatorProperties = UserCreatorProperties(),
-    @field:NestedConfigurationProperty val skin: SkinProperties = SkinProperties()
+    @field:NestedConfigurationProperty val skin: SkinProperties = SkinProperties(),
+    @field:NestedConfigurationProperty val rest: RestProperties = RestProperties(),
 ) {
     lateinit var userDetailsBaseUrl: String
 
@@ -61,6 +62,7 @@ open class SkinProperties {
     lateinit var orgLongName: String
     lateinit var orgNameKey: String
     lateinit var loginLogo: String
+    lateinit var supportEmail: String
     var cacheDuration: String = "PT30m"
     var uiVersion: Int = 2
 }
@@ -73,4 +75,8 @@ open class AlaAuthCookieProperties : CookieProperties() {
     var rememberMeMaxAge: String = "P14D"
     var quoteValue: Boolean = true
     var urlEncodeValue: Boolean = false
+}
+
+open class RestProperties {
+    var requiredScopes: List<String> = arrayListOf("users/read")
 }

--- a/src/main/kotlin/au/org/ala/cas/delegated/AlaPac4jAuthenticationConfiguration.kt
+++ b/src/main/kotlin/au/org/ala/cas/delegated/AlaPac4jAuthenticationConfiguration.kt
@@ -1,6 +1,7 @@
 package au.org.ala.cas.delegated
 
 import au.org.ala.cas.AlaCasProperties
+import au.org.ala.cas.webflow.ExtraAttributesService
 import au.org.ala.utils.logger
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
@@ -64,8 +65,9 @@ class AlaPac4jAuthenticationConfiguration {
     fun clientPrincipalFactory(
         @Autowired @Qualifier("personDirectoryAttributeRepositoryPrincipalResolver") personDirectoryPrincipalResolver: PrincipalResolver,
         @Autowired @Qualifier("cachingAttributeRepository") cachingAttributeRepository: IPersonAttributeDao, //CachingPersonAttributeDaoImpl,
-        @Autowired userCreator: UserCreator
-    ): PrincipalFactory = AlaPrincipalFactory(personDirectoryPrincipalResolver, cachingAttributeRepository, userCreator)
+        @Autowired userCreator: UserCreator,
+        @Autowired extraAttributesService: ExtraAttributesService,
+    ): PrincipalFactory = AlaPrincipalFactory(personDirectoryPrincipalResolver, cachingAttributeRepository, userCreator, extraAttributesService)
 
     // TODO How to replicate this?
     @PostConstruct

--- a/src/main/kotlin/au/org/ala/cas/delegated/AlaPrincipalFactory.kt
+++ b/src/main/kotlin/au/org/ala/cas/delegated/AlaPrincipalFactory.kt
@@ -1,6 +1,7 @@
 package au.org.ala.cas.delegated
 
 import au.org.ala.cas.booleanAttribute
+import au.org.ala.cas.webflow.ExtraAttributesService
 import au.org.ala.utils.logger
 import org.apache.commons.lang3.builder.HashCodeBuilder
 import org.apereo.cas.authentication.Credential
@@ -13,7 +14,8 @@ import javax.security.auth.login.FailedLoginException
 class AlaPrincipalFactory(
     private val principalResolver: PrincipalResolver,
     private val cachingAttributeRepository: IPersonAttributeDao, //CachingPersonAttributeDaoImpl,
-    val userCreator: UserCreator
+    val userCreator: UserCreator,
+    val extraAttributesService: ExtraAttributesService
 ) : PrincipalFactory {
 
     companion object {
@@ -89,6 +91,8 @@ class AlaPrincipalFactory(
                 throw FailedLoginException("Unable to create ALA user for $emailAddress with attributes $attributes")
             }
         }
+        // Save delegated id for future work
+        extraAttributesService.addDelegatedId(principal, id, attributes)
         // The PAC4j client support expects a principal with the same id as the input principal, so return a new
         // principal with the input id and the attributes from the db.
         return DefaultPrincipalFactory().createPrincipal(id, principal.attributes)

--- a/src/main/kotlin/au/org/ala/cas/oidc/OidcConfiguration.kt
+++ b/src/main/kotlin/au/org/ala/cas/oidc/OidcConfiguration.kt
@@ -7,11 +7,13 @@ import org.apereo.cas.authentication.principal.WebApplicationService
 import org.apereo.cas.configuration.CasConfigurationProperties
 import org.apereo.cas.support.oauth.authenticator.OAuth20CasAuthenticationBuilder
 import org.apereo.cas.support.oauth.profile.OAuth20ProfileScopeToAttributesFilter
+import org.apereo.cas.support.oauth.web.OAuth20RequestParameterResolver
 import org.apereo.cas.support.oauth.web.response.accesstoken.OAuth20TokenGenerator
 import org.apereo.cas.ticket.accesstoken.OAuth20AccessTokenFactory
 import org.apereo.cas.ticket.device.OAuth20DeviceTokenFactory
 import org.apereo.cas.ticket.device.OAuth20DeviceUserCodeFactory
 import org.apereo.cas.ticket.refreshtoken.OAuth20RefreshTokenFactory
+import org.apereo.cas.ticket.registry.TicketRegistry
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.context.config.annotation.RefreshScope
@@ -32,13 +34,12 @@ class OidcConfiguration {
         @Qualifier("defaultDeviceTokenFactory") defaultDeviceTokenFactory: OAuth20DeviceTokenFactory,
         @Qualifier("defaultRefreshTokenFactory") defaultRefreshTokenFactory: OAuth20RefreshTokenFactory,
         @Qualifier("defaultAccessTokenFactory") defaultAccessTokenFactory: OAuth20AccessTokenFactory,
-        @Qualifier(CentralAuthenticationService.BEAN_NAME) centralAuthenticationService: CentralAuthenticationService,
+        ticketRegistry: TicketRegistry,
         casProperties: CasConfigurationProperties
     ): OAuth20TokenGenerator {
         return OidcDefaultTokenGenerator(
             defaultAccessTokenFactory, defaultDeviceTokenFactory,
-            defaultDeviceUserCodeFactory, defaultRefreshTokenFactory,
-            centralAuthenticationService, casProperties
+            defaultDeviceUserCodeFactory, defaultRefreshTokenFactory, ticketRegistry, casProperties
         )
     }
 
@@ -51,8 +52,10 @@ class OidcConfiguration {
         profileScopeToAttributesFilter: OAuth20ProfileScopeToAttributesFilter,
         @Qualifier(WebApplicationService.BEAN_NAME_FACTORY)
         webApplicationServiceFactory: ServiceFactory<WebApplicationService>,
+        requestParameterResolver: OAuth20RequestParameterResolver,
         casProperties: CasConfigurationProperties
     ): OAuth20CasAuthenticationBuilder {
-        return OidcDefaultCasAuthenticationBuilder(oauthPrincipalFactory, webApplicationServiceFactory, profileScopeToAttributesFilter, casProperties)
+        return OidcDefaultCasAuthenticationBuilder(oauthPrincipalFactory, webApplicationServiceFactory,
+            profileScopeToAttributesFilter, requestParameterResolver, casProperties)
     }
 }

--- a/src/main/kotlin/au/org/ala/cas/rest/RestConfiguration.kt
+++ b/src/main/kotlin/au/org/ala/cas/rest/RestConfiguration.kt
@@ -1,0 +1,29 @@
+package au.org.ala.cas.rest
+
+import au.org.ala.cas.AlaCasProperties
+import org.apereo.cas.authentication.principal.PrincipalResolver
+import org.apereo.cas.configuration.CasConfigurationProperties
+import org.apereo.cas.oidc.OidcConfigurationContext
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.cloud.context.config.annotation.RefreshScope
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.ScopedProxyMode
+
+@Configuration
+@EnableConfigurationProperties(CasConfigurationProperties::class, AlaCasProperties::class)
+class RestConfiguration {
+
+    @Autowired
+    lateinit var alaCasProperties: AlaCasProperties
+
+    @Bean
+    @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
+    fun userLookupResource(
+        @Qualifier("oidcConfigurationContext") oidcConfigurationContext: OidcConfigurationContext,
+        @Qualifier("defaultPrincipalResolver") principalResolver: PrincipalResolver
+    ) = UserLookupResource(oidcConfigurationContext, principalResolver, alaCasProperties.rest.requiredScopes)
+
+}

--- a/src/main/kotlin/au/org/ala/cas/rest/UserLookupResource.kt
+++ b/src/main/kotlin/au/org/ala/cas/rest/UserLookupResource.kt
@@ -1,0 +1,128 @@
+package au.org.ala.cas.rest
+
+import au.org.ala.utils.logger
+import org.apache.commons.lang3.StringUtils
+import org.apache.commons.text.StringEscapeUtils
+import org.apereo.cas.authentication.principal.Principal
+import org.apereo.cas.authentication.principal.PrincipalResolver
+import org.apereo.cas.support.oauth.web.endpoints.OAuth20ConfigurationContext
+import org.apereo.cas.support.oauth.web.response.accesstoken.response.OAuth20JwtAccessTokenEncoder
+import org.apereo.cas.ticket.accesstoken.OAuth20AccessToken
+import org.apereo.cas.util.serialization.JacksonObjectMapperFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.*
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@RestController("userAuthenticationResource")
+class UserLookupResource(
+//    val authenticationService: RestAuthenticationService,
+    val configurationContext: OAuth20ConfigurationContext,
+    val principalResolver: PrincipalResolver,
+    val requiredScopes: List<String>
+) {
+
+    companion object {
+        private val LOGGER = logger()
+    }
+
+    val expiredAccessTokenResponseEntity = ResponseEntity("expired_token", HttpStatus.UNAUTHORIZED)
+    val unauthorizedResponseEntity = ResponseEntity("missing_access_token", HttpStatus.UNAUTHORIZED)
+
+    @GetMapping(
+        value = ["/v1/lookup"],
+//        consumes = ["application/x-www-form-urlencoded", "application/json"],
+        produces = ["application/json"]
+    )
+    fun authenticateRequest(
+//        @RequestBody requestBody: MultiValueMap<String?, String?>,
+        request: HttpServletRequest,
+        response: HttpServletResponse
+    ): ResponseEntity<String> {
+        return try {
+            val accessToken = getAccessTokenFromRequest(request)
+
+            return if (StringUtils.isBlank(accessToken)) {
+                LOGGER.error("Missing [{}] from the request", "access_token")
+                unauthorizedResponseEntity
+            } else {
+                val accessTokenTicket =
+                    this.configurationContext.ticketRegistry.getTicket(
+                        accessToken,
+                        OAuth20AccessToken::class.java
+                    )
+                if (accessTokenTicket == null || accessTokenTicket.isExpired) {
+                    LOGGER.error(
+                        "Access token [{}] cannot be found in the ticket registry or has expired.",
+                        accessToken
+                    )
+                    expiredAccessTokenResponseEntity
+                } else if (!accessTokenTicket.scopes.containsAll(requiredScopes)) {
+                    LOGGER.error(
+                        "Access token [{}] missing required scopes: {}",
+                        accessToken, requiredScopes
+                    )
+                    ResponseEntity("unauthorized", HttpStatus.UNAUTHORIZED)
+                } else {
+//                    AuthenticationCredentialsThreadLocalBinder.bindCurrent(accessTokenTicket.authentication)
+                    updateAccessTokenUsage(accessTokenTicket)
+
+//                    val map: Map<String, Any> = this.configurationContext.userProfileDataCreator.createFrom(accessTokenTicket, context)
+//                    this.getConfigurationContext().getUserProfileViewRenderer().render(map, accessTokenTicket, response)
+                    val user = request.getParameter("userLookup")
+                    val principal = principalResolver.resolve { user }
+                    if (principal == null) {
+                        LOGGER.info("user ({}) not found", user)
+                        ResponseEntity("not_found", HttpStatus.NOT_FOUND)
+                    } else {
+                        build(principal)
+                    }
+                }
+            }
+
+        } catch (e: Exception) {
+            LOGGER.error("Unexpected error", e)
+            ResponseEntity(StringEscapeUtils.escapeHtml4(e.message), HttpStatus.INTERNAL_SERVER_ERROR)
+        }
+    }
+
+    private val MAPPER = JacksonObjectMapperFactory.builder().defaultTypingEnabled(false).build().toObjectMapper()
+
+    @Throws(java.lang.Exception::class)
+    fun build(result: Principal): ResponseEntity<String> {
+        return ResponseEntity(MAPPER.writeValueAsString(result), HttpStatus.OK)
+    }
+
+    protected fun getAccessTokenFromRequest(request: HttpServletRequest): String? {
+        var accessToken = request.getParameter("access_token")
+        if (StringUtils.isBlank(accessToken)) {
+            val authHeader = request.getHeader("Authorization")
+            if (StringUtils.isNotBlank(authHeader) && authHeader.lowercase(Locale.getDefault())
+                    .startsWith("bearer".lowercase(Locale.getDefault()) + " ")
+            ) {
+                accessToken = authHeader.substring("bearer".length + 1)
+            }
+        }
+        LOGGER.debug("[{}]: [{}]", "access_token", accessToken)
+        return this.extractAccessTokenFrom(accessToken)
+    }
+
+    protected fun extractAccessTokenFrom(token: String?): String? {
+        return OAuth20JwtAccessTokenEncoder.builder()
+            .accessTokenJwtBuilder(this.configurationContext.accessTokenJwtBuilder).build().decode(token)
+    }
+
+    @Throws(java.lang.Exception::class)
+    protected fun updateAccessTokenUsage(accessTokenTicket: OAuth20AccessToken) {
+        accessTokenTicket.update()
+        if (accessTokenTicket.isExpired) {
+            this.configurationContext.ticketRegistry.deleteTicket(accessTokenTicket.id)
+        } else {
+            this.configurationContext.ticketRegistry.updateTicket(accessTokenTicket)
+        }
+    }
+
+}

--- a/src/main/kotlin/au/org/ala/cas/thymeleaf/AlaCasThemesConfiguration.kt
+++ b/src/main/kotlin/au/org/ala/cas/thymeleaf/AlaCasThemesConfiguration.kt
@@ -33,6 +33,7 @@ class AlaCasThemesConfiguration {
         const val ALA_UI_VERSION = "alaUiVersion"
         const val ALA_PROPERTIES = "ala"
         const val LOGIN_LOGO = "loginLogo"
+        const val SUPPORT_EMAIL = "supportEmail"
 
         val log = logger()
 
@@ -54,6 +55,7 @@ class AlaCasThemesConfiguration {
                 CREATE_ACCOUNT_URL to alaCasProperties.skin.createAccountUrl,
                 ALA_UI_VERSION to "ala-ui-${alaCasProperties.skin.uiVersion}",
                 LOGIN_LOGO to alaCasProperties.skin.loginLogo,
+                SUPPORT_EMAIL to alaCasProperties.skin.supportEmail,
                 ALA_PROPERTIES to alaCasProperties
             ).forEach(action)
         }

--- a/src/main/kotlin/au/org/ala/cas/webflow/UpdatePasswordAction.kt
+++ b/src/main/kotlin/au/org/ala/cas/webflow/UpdatePasswordAction.kt
@@ -14,6 +14,7 @@ import org.springframework.transaction.support.TransactionTemplate
 import org.springframework.webflow.action.AbstractAction
 import org.springframework.webflow.execution.Event
 import org.springframework.webflow.execution.RequestContext
+import java.nio.CharBuffer
 import javax.sql.DataSource
 
 class UpdatePasswordAction(
@@ -35,11 +36,11 @@ class UpdatePasswordAction(
         val authentication = WebUtils.getAuthentication(context)
         val userid = authentication.alaUserId()
         val legacyPassword = authentication.booleanAttribute("legacyPassword") ?: false
-        if (credential != null && credential is UsernamePasswordCredential && !credential.password.isNullOrBlank() && legacyPassword && userid != null) {
+        if (credential != null && credential is UsernamePasswordCredential && credential.password.isNotEmpty() && legacyPassword && userid != null) {
             log.info("Upgrading legacy password for {} ({})", credential.username, userid)
             val params = mapOf(
                 "userid" to userid,
-                "password" to passwordEncoder.encode(credential.password)
+                "password" to passwordEncoder.encode(CharBuffer.wrap(credential.password))
             )
             transactionTemplate.execute { status ->
                 try {

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -7,4 +7,5 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=au.org.ala.cas.jn
   au.org.ala.cas.mongo.MongoIndexConfiguration,\
   au.org.ala.cas.session.MongoSpringSessionConfiguration,\
   au.org.ala.cas.flyway.AlaFlywayConfiguration,\
-  au.org.ala.cas.oidc.OidcConfiguration
+  au.org.ala.cas.oidc.OidcConfiguration,\
+  au.org.ala.cas.rest.RestConfiguration

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -268,10 +268,10 @@ cas:
       driverClass: com.mysql.cj.jdbc.Driver
       validationQuery: /* ping */ SELECT 1
   tgc:
-    maxAge: 86400 # Same as TGT expiry
+    maxAge: 31536000 # Same as TGT expiry
     secure: true
     httpOnly: true
-    rememberMeMaxAge: PT7884000S #7884000
+    rememberMeMaxAge: -1 # Never expires
     crypto:
       enabled: false
 #    encryptionKey=
@@ -282,11 +282,11 @@ cas:
   ticket:
     tgt:
       primary:
-        maxTimeToLiveInSeconds: 86400 # PT24H
-        timeToKillInSeconds: 86400 # PT24H
+        maxTimeToLiveInSeconds: 31536000 # P1Y
+        timeToKillInSeconds: 7884000 # P3M
       rememberMe:
         enabled: true
-        timeToKillInSeconds: 7884000 # P3M
+        timeToKillInSeconds: -1 # Never expires
     registry:
 #      cleaner:
 #        schedule:
@@ -322,6 +322,7 @@ cas:
     followServiceRedirects: true
     redirectParameter: url
     confirmLogout: false
+    remove-descendant-tickets: false
   slo:
     disabled: false
     asynchronous: true
@@ -410,5 +411,6 @@ ala:
     orgLongName: Atlas Of Living Australia
     orgNameKey: ala
     cacheDuration: PT30m # 1800000
+    supportEmail: support@ala.org.au
     ui-version: 2
 debug: false

--- a/src/main/resources/custom_messages.properties
+++ b/src/main/resources/custom_messages.properties
@@ -47,8 +47,8 @@ screen.logout.success=You have successfully logged out of the ALA's Central Auth
 screen.unavailable.header=ALA auth error
 screen.unavailable.heading=ALA auth is unable to process this request: "{0}:{1}"
 screen.unavailable.message=There was an error trying to complete your request.<br> \
-<strong>Please attempt to <a href="logout">log out</a> and try again.  If the problem persists please contact <a href="mailto:support@ala.org.au">support@ala.org.au</a> \
+<strong>Please attempt to <a href="logout">log out</a> and try again.  If the problem persists please contact <a href="mailto:{0}">{0}</a> \
   with the below details for further assistance.</strong>
 
 screen.accountdisabled.heading=This account is not yet activated or has been locked.
-screen.accountdisabled.message=Please check your email for account activation instructions or contact <a href="mailto:support@ala.org.au">support@ala.org.au</a>.
+screen.accountdisabled.message=Please check your email for account activation instructions or contact <a href="mailto:{0}">{0}</a>.

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -30,7 +30,7 @@
                         <h2 class="panel-title" th:utext="#{screen.unavailable.heading(${status},${error})}">CAS is unable to process this request: "{0}:{1}"</h2>
                     </div>
                     <div class="panel-body">
-                        <p th:utext="#{screen.unavailable.message}">screen.unavailable.message would go here</p>
+                        <p th:utext="#{screen.unavailable.message($supportEmail)}">screen.unavailable.message would go here</p>
                         <pre id="errorMsg" class="mt-4" style="white-space: pre-wrap;" th:text="${'Error: ' + message}">error message would go here</pre>
                         <p id="errorDetails">
                             <button type="button" class="btn btn-shutdown"

--- a/src/main/resources/templates/login-error/casAccountDisabledView.html
+++ b/src/main/resources/templates/login-error/casAccountDisabledView.html
@@ -13,7 +13,7 @@
 <main role="main" class="container mt-3 mb-3">
     <div layout:fragment="content" class="banner banner-danger alert alert-danger mdc-card card p-4 m-auto w-lg-66">
         <h2 th:utext="#{screen.accountdisabled.heading}">This account has been disabled.</h2>
-        <p th:utext="#{screen.accountdisabled.message}">Please contact the system administrator to regain
+        <p th:utext="#{screen.accountdisabled.message($supportEmail)}">Please contact the system administrator to regain
             access.</p>
     </div>
 </main>


### PR DESCRIPTION
- Update CAS to 6.6.5
- Update Spring Boot to 2.7.4 to match CAS
- Add HTTP API endpoint for looking up user in same format as HTTP API login
- Adjust default tgt expiry times to 1y, 3m access time, forever remember me (overridden in external config)
- Add configurable support email to account disabled message (#49)
- Add recording users delegated login as profile attribute