### PR TITLE
Hotfix for master that implements MySQL 8.4 support

### DIFF
--- a/META-INF/context.xml
+++ b/META-INF/context.xml
@@ -3,12 +3,14 @@
     <Resource name="jdbccas" auth="Container"
               factory="com.zaxxer.hikari.HikariJNDIFactory"
               type="javax.sql.DataSource"
-              driverClassName="com.mysql.jdbc.Driver"
+              driverClassName="com.mysql.cj.jdbc.Driver"
               jdbcUrl="jdbc:mysql://localhost:3306/emmet?serverTimezone=Australia/Sydney"
               username="root"
               password="password"
               dataSource.cachePrepStmts="true"
               dataSource.prepStmtCacheSize="250"
               dataSource.prepStmtCacheSqlLimit="2048"
+              dataSource.nullCatalogMeansCurrent="true"
+              dataSource.nullNamePatternMatchesAll="true"
     />
 </Context>

--- a/README.md
+++ b/README.md
@@ -34,13 +34,12 @@ By default, CAS will load properties from `/etc/cas/config` but can be changed b
     of each version `ddl-auto` should be set to `update` to get the latest changes from JPA (or run the provided SQL file to upgrade a CAS 4 JPA ticket registry to CAS 5).
   - `cas.authn.pac4j.facebook|google|twitter` will require id and secret to be set.
 
-**NOTE:** The MySQL driver used by this CAS version is 5.1.43.  This DB driver requires that the server returns a timezone
-in the form `Australia/Sydney`, whereas the MySQL versions available on Ubuntu 16.04 will tell the client `AEST` (which
-causes an Exception in the client).  The simplest fix is to override the server timezone in the JDBC URL by appending 
-`?serverTimezone=Australia/Sydney` to the URL.
+**NOTE:** This overlay uses MySQL Connector/J 8 LTS (`com.mysql:mysql-connector-j`).  The JDBC driver class is
+`com.mysql.cj.jdbc.Driver`.  If the server returns an ambiguous timezone such as `AEST`, override the server timezone in
+the JDBC URL by appending `?serverTimezone=Australia/Sydney` to the URL.
 
-*IF USING MYSQL Connector 6.0+* note that the `UserCreatorALA` uses Spring JDBC's `SimpleJdbcCall` to execute a stored procedure.
-Spring JDBC makes some assumptions about the behaviour of the JDBC driver which [changed in `mysql-connector-java` 6.0+](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-properties-changed.html)
+The `UserCreatorALA` uses Spring JDBC's `SimpleJdbcCall` to execute a stored procedure.  Spring JDBC makes some
+assumptions about the behaviour of the JDBC driver which [changed in Connector/J 6.0+](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-properties-changed.html),
 and as such the following driver properties are also required:
  - `nullCatalogMeansCurrent=true`
  - `nullNamePatternMatchesAll=true`

--- a/etc/cas/config/application.yml
+++ b/etc/cas/config/application.yml
@@ -54,7 +54,7 @@ jndi:
   hikari:
     jdbccas:
       name: jdbccas
-      driverClass: com.mysql.jdbc.Driver
+      driverClass: com.mysql.cj.jdbc.Driver
       url: jdbc:mysql://localhost/cas[?serverTimezone=Australia/Sydney]
       user: username
       password: password
@@ -62,6 +62,8 @@ jndi:
         cachePrepStmts: true
         prepStmtCacheSize: 250
         prepStmtCacheSqlLimit: 2048
+        nullCatalogMeansCurrent: true
+        nullNamePatternMatchesAll: true
 
 flyway:
   url: jdbc:mysql://localhost/cas[?serverTimezone=Australia/Sydney]

--- a/pom-test.xml
+++ b/pom-test.xml
@@ -677,9 +677,9 @@
         <!--</dependency>-->
         <!-- End CAS provided JARs -->
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.43</version>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.4.0</version>
             <scope>runtime</scope>
         </dependency>
         <!-- Here be webjars -->

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>cas</artifactId>
     <packaging>war</packaging>
     <!-- Version should ${cas.version}-${ala.build.version}(-SNAPSHOT)? -->
-    <version>6.5.6-3</version>
+    <version>6.5.6-4-SNAPSHOT</version>
 
     <name>ALA CAS</name>
     <description>ALA Central Authentication Service</description>

--- a/pom.xml
+++ b/pom.xml
@@ -196,14 +196,15 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-<!--            <plugin>-->
-<!--                <artifactId>maven-surefire-plugin</artifactId>-->
-<!--                <version>3.0.0-M5</version>-->
-<!--&lt;!&ndash;                <version>2.22.1</version>&ndash;&gt;-->
-<!--                <configuration>-->
-<!--                    <jvm>${env.JAVA_HOME}/bin/java</jvm>-->
-<!--                </configuration>-->
-<!--            </plugin>-->
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <api.version>${docker.api.version}</api.version>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
         <finalName>cas</finalName>
     </build>
@@ -739,9 +740,9 @@
         </dependency>
         <!-- End CAS provided JARs -->
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.29</version>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.4.0</version>
 <!--            <scope>runtime</scope>-->
         </dependency>
         <!-- Here be webjars -->
@@ -897,11 +898,18 @@
             <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <version>1.21.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>
         <cas.version>6.5.6</cas.version>
         <springboot.version>2.6.3</springboot.version>
+        <docker.api.version>1.40</docker.api.version>
         <!-- app.server could be -jetty, -undertow, -tomcat, or blank if you plan to provide appserver -->
         <!-- we use blank to create a blank war and spring boot repackage to build an executable Tomcat jar -->
         <app.server></app.server>

--- a/src/main/kotlin/au/org/ala/cas/events/AlaCasEventListener.kt
+++ b/src/main/kotlin/au/org/ala/cas/events/AlaCasEventListener.kt
@@ -1,19 +1,17 @@
 package au.org.ala.cas.events
 
 import au.org.ala.cas.alaUserId
+import au.org.ala.cas.jdbc.AlaUserJdbcService
 import au.org.ala.cas.stringAttribute
 import au.org.ala.utils.logger
 import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketCreatedEvent
 import org.apereo.services.persondir.IPersonAttributeDao
 import org.apereo.services.persondir.support.CachingPersonAttributeDaoImpl
 import org.springframework.context.event.EventListener
-import org.springframework.jdbc.core.JdbcTemplate
 import java.util.concurrent.ExecutorService
-import javax.sql.DataSource
 
 open class AlaCasEventListener(
-    val dataSource: DataSource,
-    val updateSql: String,
+    val alaUserJdbcService: AlaUserJdbcService,
     val executorService: ExecutorService,
     val cachingAttributeRepository: IPersonAttributeDao //CachingPersonAttributeDaoImpl
 ) {
@@ -27,15 +25,13 @@ open class AlaCasEventListener(
         val authentication = casTicketGrantingTicketCreatedEvent.ticketGrantingTicket?.authentication
         log.debug("Handling CAS TGT created event for : {}", authentication)
         val userid = authentication?.alaUserId()
-        val email = authentication?.stringAttribute("email")
         if (userid != null) {
             executorService.execute {
                 try {
-                    val template = JdbcTemplate(dataSource)
-                    template.update(updateSql, userid)
+                    alaUserJdbcService.updateLastLogin(userid)
 //                    email?.let { cachingAttributeRepository.removeUserAttributes(it) }
                 } catch (e: Exception) {
-                    log.error("Couldn't update last login time for {} using SQL {}", userid, updateSql, e)
+                    log.error("Couldn't update last login time for {}", userid, e)
                 }
             }
         }

--- a/src/main/kotlin/au/org/ala/cas/events/AlaEventsConfiguration.kt
+++ b/src/main/kotlin/au/org/ala/cas/events/AlaEventsConfiguration.kt
@@ -1,6 +1,7 @@
 package au.org.ala.cas.events
 
 import au.org.ala.cas.AlaCasProperties
+import au.org.ala.cas.jdbc.AlaUserJdbcService
 import org.apereo.cas.configuration.support.JpaBeans
 import org.apereo.services.persondir.IPersonAttributeDao
 import org.apereo.services.persondir.support.CachingPersonAttributeDaoImpl
@@ -10,6 +11,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.datasource.DataSourceTransactionManager
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
@@ -28,7 +30,8 @@ class AlaEventsConfiguration {
     fun alaCasEventListener(
         @Autowired @Qualifier("cachingAttributeRepository") cachingAttributeRepository: IPersonAttributeDao
     ): AlaCasEventListener {
-        return AlaCasEventListener(JpaBeans.newDataSource(alaCasProperties.userCreator.jdbc), alaCasProperties.userCreator.jdbc.updateLastLoginTimeSql, lastLoginExecutor(), cachingAttributeRepository)
+        val dataSource = JpaBeans.newDataSource(alaCasProperties.userCreator.jdbc)
+        val jdbcService = AlaUserJdbcService(alaCasProperties, dataSource, DataSourceTransactionManager(dataSource))
+        return AlaCasEventListener(jdbcService, lastLoginExecutor(), cachingAttributeRepository)
     }
 }
-

--- a/src/main/kotlin/au/org/ala/cas/jdbc/AlaUserJdbcService.kt
+++ b/src/main/kotlin/au/org/ala/cas/jdbc/AlaUserJdbcService.kt
@@ -1,0 +1,53 @@
+package au.org.ala.cas.jdbc
+
+import au.org.ala.cas.AlaCasProperties
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.TransactionTemplate
+import javax.sql.DataSource
+
+class AlaUserJdbcService(
+    private val alaCasProperties: AlaCasProperties,
+    dataSource: DataSource,
+    transactionManager: PlatformTransactionManager
+) {
+    private val jdbcTemplate = JdbcTemplate(dataSource)
+    private val namedJdbcTemplate = NamedParameterJdbcTemplate(dataSource)
+    private val transactionTemplate = TransactionTemplate(transactionManager)
+
+    fun updateLastLogin(userid: Long): Int = jdbcTemplate.update(alaCasProperties.userCreator.jdbc.updateLastLoginTimeSql, userid)
+
+    fun countProfile(userid: Long, name: String): Int {
+        return namedJdbcTemplate.queryForObject(
+            alaCasProperties.userCreator.jdbc.countExtraAttributeSql,
+            mapOf("userid" to userid, "name" to name),
+            Int::class.java
+        ) ?: 0
+    }
+
+    fun shouldOfferSurvey(userid: Long): Boolean = countProfile(userid, "affiliation") == 0
+
+    fun upsertProfile(userid: Long, name: String, value: String): Int {
+        val params = mapOf("userid" to userid, "name" to name, "value" to value)
+        return if (countProfile(userid, name) > 0) {
+            namedJdbcTemplate.update(alaCasProperties.userCreator.jdbc.updateExtraAttributeSql, params)
+        } else {
+            namedJdbcTemplate.update(alaCasProperties.userCreator.jdbc.insertExtraAttributeSql, params)
+        }
+    }
+
+    fun updateLegacyPassword(userid: Long, encodedPassword: String) {
+        val params = mapOf("userid" to userid, "password" to encodedPassword)
+        transactionTemplate.execute { status ->
+            try {
+                alaCasProperties.userCreator.jdbc.updatePasswordSqls.forEach { sql ->
+                    namedJdbcTemplate.update(sql, params)
+                }
+            } catch (e: Exception) {
+                status.setRollbackOnly()
+                throw e
+            }
+        }
+    }
+}

--- a/src/main/kotlin/au/org/ala/cas/webflow/AlaCasWebflowConfiguration.kt
+++ b/src/main/kotlin/au/org/ala/cas/webflow/AlaCasWebflowConfiguration.kt
@@ -1,6 +1,7 @@
 package au.org.ala.cas.webflow
 
 import au.org.ala.cas.AlaCasProperties
+import au.org.ala.cas.jdbc.AlaUserJdbcService
 import au.org.ala.utils.logger
 import org.apereo.cas.authentication.principal.ServiceFactory
 import org.apereo.cas.authentication.principal.WebApplicationService
@@ -99,7 +100,10 @@ class AlaCasWebflowConfiguration : CasWebflowExecutionPlanConfigurer {
 //    lateinit var webApplicationServiceFactory: ServiceFactory<WebApplicationService>
 
     @Bean
-    fun extraAttributesService() = ExtraAttributesService(alaCasProperties, userCreatorDataSource, userCreatorTransactionManager, cachingAttributeRepository, messageSource)
+    fun alaUserJdbcService() = AlaUserJdbcService(alaCasProperties, userCreatorDataSource, userCreatorTransactionManager)
+
+    @Bean
+    fun extraAttributesService() = ExtraAttributesService(alaCasProperties, alaUserJdbcService(), cachingAttributeRepository, messageSource)
 
     @Bean
     @RefreshScope
@@ -140,7 +144,7 @@ class AlaCasWebflowConfiguration : CasWebflowExecutionPlanConfigurer {
     @Qualifier(AlaCasWebflowConfigurer.ACTION_UPDATE_PASSWORD)
     fun updatePasswordAction(): Action = UpdatePasswordAction(
         alaCasProperties, PasswordEncoderUtils.newPasswordEncoder(alaCasProperties.userCreator.passwordEncoder, applicationContext),
-        userCreatorDataSource, userCreatorTransactionManager
+        alaUserJdbcService()
     )
 
 //    @RefreshScope
@@ -158,7 +162,7 @@ class AlaCasWebflowConfiguration : CasWebflowExecutionPlanConfigurer {
 
     @Bean
     @Qualifier(AlaCasWebflowConfigurer.DECISION_ID_SURVEY)
-    fun decisionSurveyAction() = DecisionSurveyAction(alaCasProperties, userCreatorDataSource)
+    fun decisionSurveyAction() = DecisionSurveyAction(alaCasProperties, alaUserJdbcService())
 
     @Bean
     @Qualifier(AlaCasWebflowConfigurer.STATE_ID_SAVE_SURVEY_ACTION)

--- a/src/main/kotlin/au/org/ala/cas/webflow/DecisionSurveyAction.kt
+++ b/src/main/kotlin/au/org/ala/cas/webflow/DecisionSurveyAction.kt
@@ -2,21 +2,19 @@ package au.org.ala.cas.webflow
 
 import au.org.ala.cas.AlaCasProperties
 import au.org.ala.cas.alaUserId
+import au.org.ala.cas.jdbc.AlaUserJdbcService
 import au.org.ala.utils.logger
 import org.apereo.cas.web.support.WebUtils
-import org.springframework.dao.EmptyResultDataAccessException
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.webflow.action.AbstractAction
 import org.springframework.webflow.execution.Event
 import org.springframework.webflow.execution.RequestContext
-import javax.sql.DataSource
 
 /**
  * Webflow Action to decide whether to offer the user a survey or not
  */
 class DecisionSurveyAction(
     val alaCasProperties: AlaCasProperties,
-    val dataSource: DataSource
+    val alaUserJdbcService: AlaUserJdbcService
 ) : AbstractAction() {
 
     companion object {
@@ -34,19 +32,9 @@ class DecisionSurveyAction(
         }
 
         if (authentication?.principal != null) {
-
-            val template = NamedParameterJdbcTemplate(dataSource)
-            val affiliationCount = try {
-                template.queryForObject(
-                    alaCasProperties.userCreator.jdbc.countExtraAttributeSql,
-                    mapOf("userid" to userid, "name" to "affiliation"),
-                    Integer::class.java
-                )
-            } catch(e: EmptyResultDataAccessException) {
-                0
-            }
-            log.debug("Survey decision for {}: {}", userid, affiliationCount)
-            return if (affiliationCount == 0) yes() else no()
+            val offerSurvey = alaUserJdbcService.shouldOfferSurvey(userid)
+            log.debug("Survey decision for {}: {}", userid, offerSurvey)
+            return if (offerSurvey) yes() else no()
         }
         return no()
     }

--- a/src/main/kotlin/au/org/ala/cas/webflow/ExtraAttributesService.kt
+++ b/src/main/kotlin/au/org/ala/cas/webflow/ExtraAttributesService.kt
@@ -1,19 +1,15 @@
 package au.org.ala.cas.webflow
 
 import au.org.ala.cas.AlaCasProperties
+import au.org.ala.cas.jdbc.AlaUserJdbcService
 import au.org.ala.cas.setSingleAttributeValue
 import au.org.ala.cas.stringAttribute
 import au.org.ala.utils.logger
 import org.apereo.cas.authentication.Authentication
 import org.apereo.services.persondir.IPersonAttributeDao
-import org.apereo.services.persondir.support.CachingPersonAttributeDaoImpl
 import org.springframework.context.MessageSource
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
-import org.springframework.jdbc.datasource.DataSourceTransactionManager
 import org.springframework.stereotype.Component
-import org.springframework.transaction.support.TransactionTemplate
 import java.util.*
-import javax.sql.DataSource
 
 /**
  * Service for interacting with extra attributes on a users profile.
@@ -21,8 +17,7 @@ import javax.sql.DataSource
 @Component
 class ExtraAttributesService(
     private val alaCasProperties: AlaCasProperties,
-    private val dataSource: DataSource,
-    transactionManager: DataSourceTransactionManager,
+    private val alaUserJdbcService: AlaUserJdbcService,
     private val cachingAttributeRepository: IPersonAttributeDao, //CachingPersonAttributeDaoImpl,
     private val messageSource: MessageSource
 ) {
@@ -39,51 +34,35 @@ class ExtraAttributesService(
 
     }
 
-    private val transactionTemplate: TransactionTemplate = TransactionTemplate(transactionManager)
-
     fun updateExtraAttrs(userid: Long, authentication: Authentication, extraAttrs: ExtraAttrs) {
-        val email = authentication.stringAttribute("email")
-
-        transactionTemplate.execute { status ->
-            try {
-                val template = NamedParameterJdbcTemplate(dataSource)
-                listOf(ORGANISATION to extraAttrs.organisation,
-                    CITY to extraAttrs.city,
-                    STATE to extraAttrs.state,
-                    COUNTRY to extraAttrs.country
-                ).forEach { (name, value) ->
-                    updateField(template, userid, authentication, name, value)
-                }
-
-                // invalidate cache for the new user attributes
-                // TODO there must be a less coupled way of achieving this
-
-                // TODO Re-enable attribute caching
-//                email?.let { cachingAttributeRepository.removeUserAttributes(it) }
-            } catch (e: Exception) {
-                // If we can't set the properties, just log and move on
-                // because none of these properties are required.
-                log.warn("Rolling back transaction because of exception", e)
-                status.setRollbackOnly()
-//                throw e
+        try {
+            listOf(ORGANISATION to extraAttrs.organisation,
+                CITY to extraAttrs.city,
+                STATE to extraAttrs.state,
+                COUNTRY to extraAttrs.country
+            ).forEach { (name, value) ->
+                updateField(userid, authentication, name, value)
             }
+
+            // invalidate cache for the new user attributes
+            // TODO there must be a less coupled way of achieving this
+
+            // TODO Re-enable attribute caching
+//                email?.let { cachingAttributeRepository.removeUserAttributes(it) }
+        } catch (e: Exception) {
+            // If we can't set the properties, just log and move on because none of these properties are required.
+            log.warn("Couldn't update extra attributes", e)
+//                throw e
         }
 
     }
 
     fun updateUserSurveyResult(userid: Long, survey: Survey) {
-        transactionTemplate.execute { status ->
-            try {
-                val template = NamedParameterJdbcTemplate(dataSource)
-
-                updateField(template, userid, AFFILIATION, survey.affiliation)
-
-            } catch (e: Exception) {
-                // If we can't save the survey, just log and move on because we don't want to
-                // prevent the user from actually logging in
-                log.warn("Rolling back transaction because of exception", e)
-                status.setRollbackOnly()
-            }
+        try {
+            updateField(userid, AFFILIATION, survey.affiliation)
+        } catch (e: Exception) {
+            // If we can't save the survey, just log and move on because we don't want to prevent the user from actually logging in
+            log.warn("Couldn't update user survey result", e)
         }
     }
 
@@ -92,45 +71,41 @@ class ExtraAttributesService(
      */
     fun surveyOptions(locale: Locale): Map<String, String> {
         val args = emptyArray<String>()
-        return linkedMapOf(
-            "" to messageSource.getMessage("ala.affiliations.noneSelected", args, "-- Please select one --", locale),
-            "community" to messageSource.getMessage("ala.affiliations.community", args, "Community based organisation – club, society, landcare", locale),
-            "education" to messageSource.getMessage("ala.affiliations.education", args, "Education – primary and secondary schools, TAFE, environmental or wildlife education", locale),
-            "firstNationsOrg" to messageSource.getMessage("ala.affiliations.firstNationsOrg", args, "First Nations organisation", locale),
-            "government" to messageSource.getMessage("ala.affiliations.government", args, "Government – federal, state and local", locale),
-            "industry" to messageSource.getMessage("ala.affiliations.industry", args, "Industry, commercial, business or retail", locale),
-            "mri" to messageSource.getMessage("ala.affiliations.mri", args, "Medical Research Institute (MRI)", locale),
-            "museum" to messageSource.getMessage("ala.affiliations.museum", args, "Museum, herbarium, library, botanic gardens", locale),
-            "nfp" to messageSource.getMessage("ala.affiliations.nfp", args, "Not for profit", locale),
-            "otherResearch" to messageSource.getMessage("ala.affiliations.otherResearch", args, "Other research organisation, unaffiliated researcher", locale),
-            "private" to messageSource.getMessage("ala.affiliations.private", args, "Private user", locale),
-            "publiclyFunded" to messageSource.getMessage("ala.affiliations.publiclyFunded", args, "Publicly Funded Research Agency (PFRA) e.g. CSIRO, AIMS, DSTO", locale),
-            "uniResearch" to messageSource.getMessage("ala.affiliations.uniResearch", args, "University – faculty, researcher", locale),
-            "uniGeneral" to messageSource.getMessage("ala.affiliations.uniGeneral", args, "University - general staff, administration, management", locale),
-            "uniStudent" to messageSource.getMessage("ala.affiliations.uniStudent", args, "University – student", locale),
-            "volunteer" to messageSource.getMessage("ala.affiliations.volunteer", args, "Volunteer, citizen scientist", locale),
-            "wildlife" to messageSource.getMessage("ala.affiliations.wildlife", args, "Wildlife park, sanctuary, zoo, aquarium, wildlife rescue", locale),
-            "other" to messageSource.getMessage("ala.affiliations.other", args, "Other", locale),
-            "disinclinedToAcquiesce" to messageSource.getMessage("ala.affiliations.disinclinedToAcquiesce", args, "Prefer not to say", locale)
+        fun message(code: String, defaultMessage: String) = messageSource.getMessage(code, args, defaultMessage, locale) ?: defaultMessage
+
+        return linkedMapOf<String, String>(
+            "" to message("ala.affiliations.noneSelected", "-- Please select one --"),
+            "community" to message("ala.affiliations.community", "Community based organisation – club, society, landcare"),
+            "education" to message("ala.affiliations.education", "Education – primary and secondary schools, TAFE, environmental or wildlife education"),
+            "firstNationsOrg" to message("ala.affiliations.firstNationsOrg", "First Nations organisation"),
+            "government" to message("ala.affiliations.government", "Government – federal, state and local"),
+            "industry" to message("ala.affiliations.industry", "Industry, commercial, business or retail"),
+            "mri" to message("ala.affiliations.mri", "Medical Research Institute (MRI)"),
+            "museum" to message("ala.affiliations.museum", "Museum, herbarium, library, botanic gardens"),
+            "nfp" to message("ala.affiliations.nfp", "Not for profit"),
+            "otherResearch" to message("ala.affiliations.otherResearch", "Other research organisation, unaffiliated researcher"),
+            "private" to message("ala.affiliations.private", "Private user"),
+            "publiclyFunded" to message("ala.affiliations.publiclyFunded", "Publicly Funded Research Agency (PFRA) e.g. CSIRO, AIMS, DSTO"),
+            "uniResearch" to message("ala.affiliations.uniResearch", "University – faculty, researcher"),
+            "uniGeneral" to message("ala.affiliations.uniGeneral", "University - general staff, administration, management"),
+            "uniStudent" to message("ala.affiliations.uniStudent", "University – student"),
+            "volunteer" to message("ala.affiliations.volunteer", "Volunteer, citizen scientist"),
+            "wildlife" to message("ala.affiliations.wildlife", "Wildlife park, sanctuary, zoo, aquarium, wildlife rescue"),
+            "other" to message("ala.affiliations.other", "Other"),
+            "disinclinedToAcquiesce" to message("ala.affiliations.disinclinedToAcquiesce", "Prefer not to say")
         )
     }
 
-    private fun updateField(template: NamedParameterJdbcTemplate, userid: Long, authentication: Authentication, name: String, value: String) {
+    private fun updateField(userid: Long, authentication: Authentication, name: String, value: String) {
         if (value != authentication.stringAttribute(name)) {
-            updateField(template, userid, name, value)
+            updateField(userid, name, value)
             authentication.principal.attributes.setSingleAttributeValue(name, value)
             if (authentication.attributes.containsKey(name)) authentication.attributes.setSingleAttributeValue(name, value)
         }
     }
 
-    private fun updateField(template: NamedParameterJdbcTemplate, userid: Long, name: String, value: String) {
-        val params = mapOf("userid" to userid, "name" to name, "value" to value)
-        val result = template.queryForObject(alaCasProperties.userCreator.jdbc.countExtraAttributeSql, params, Integer::class.java)
-        val updateCount = if (result > 0) {
-            template.update(alaCasProperties.userCreator.jdbc.updateExtraAttributeSql, params)
-        } else {
-            template.update(alaCasProperties.userCreator.jdbc.insertExtraAttributeSql, params)
-        }
+    private fun updateField(userid: Long, name: String, value: String) {
+        val updateCount = alaUserJdbcService.upsertProfile(userid, name, value)
         if (updateCount != 1) {
             SaveExtraAttrsAction.log.warn("Insert / update field for {}, {}, {} returned {} updates", userid, name, value, updateCount)
         }

--- a/src/main/kotlin/au/org/ala/cas/webflow/UpdatePasswordAction.kt
+++ b/src/main/kotlin/au/org/ala/cas/webflow/UpdatePasswordAction.kt
@@ -3,32 +3,24 @@ package au.org.ala.cas.webflow
 import au.org.ala.cas.AlaCasProperties
 import au.org.ala.cas.alaUserId
 import au.org.ala.cas.booleanAttribute
+import au.org.ala.cas.jdbc.AlaUserJdbcService
 import au.org.ala.utils.logger
 import org.apereo.cas.authentication.credential.UsernamePasswordCredential
 import org.apereo.cas.web.support.WebUtils
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
-import org.springframework.jdbc.datasource.DataSourceTransactionManager
 import org.springframework.security.crypto.password.PasswordEncoder
-import org.springframework.transaction.PlatformTransactionManager
-import org.springframework.transaction.support.TransactionTemplate
 import org.springframework.webflow.action.AbstractAction
 import org.springframework.webflow.execution.Event
 import org.springframework.webflow.execution.RequestContext
-import javax.sql.DataSource
 
 class UpdatePasswordAction(
     val alaCasProperties: AlaCasProperties,
     val passwordEncoder: PasswordEncoder,
-    dataSource: DataSource,
-    transactionManager: PlatformTransactionManager
+    val alaUserJdbcService: AlaUserJdbcService
 ) : AbstractAction() {
 
     companion object {
         val log = logger()
     }
-
-    val transactionTemplate = TransactionTemplate(transactionManager)
-    val template = NamedParameterJdbcTemplate((transactionManager as? DataSourceTransactionManager)?.dataSource ?: dataSource)
 
     override fun doExecute(context: RequestContext): Event {
         val credential = WebUtils.getCredential(context)
@@ -37,22 +29,10 @@ class UpdatePasswordAction(
         val legacyPassword = authentication.booleanAttribute("legacyPassword") ?: false
         if (credential != null && credential is UsernamePasswordCredential && !credential.password.isNullOrBlank() && legacyPassword && userid != null) {
             log.info("Upgrading legacy password for {} ({})", credential.username, userid)
-            val params = mapOf(
-                "userid" to userid,
-                "password" to passwordEncoder.encode(credential.password)
-            )
-            transactionTemplate.execute { status ->
-                try {
-                    alaCasProperties.userCreator.jdbc.updatePasswordSqls.forEach { sql ->
-                        val rowsUpdated = template.update(sql, params)
-                        if (rowsUpdated == 0) {
-                            log.warn("SQL {} with params {} returned 0 updated rows", sql, params)
-                        }
-                    }
-                } catch (e: Exception) {
-                    log.warn("Couldn't update password for {} ({})", credential.username, userid, e)
-                    status.setRollbackOnly()
-                }
+            try {
+                alaUserJdbcService.updateLegacyPassword(userid, passwordEncoder.encode(credential.password))
+            } catch (e: Exception) {
+                log.warn("Couldn't update password for {} ({})", credential.username, userid, e)
             }
         }
         return success()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -141,7 +141,7 @@ cas:
             characterEncoding: UTF-8
             strength: 10
         - dataSourceName: java:comp/env/jdbccas
-          sql: SELECT p.password as password, not u.activated or u.locked as disabled, COALESCE(p.expiry < CURRENT_TIMESTAMP(), 0) as expired, TRUE as legacy_password FROM passwords p JOIN users u ON u.userid = p.userid AND p.status = 'CURRENT' WHERE u.username = ?;
+          sql: SELECT p.password as password, not u.activated or u.locked as disabled, COALESCE(p.expiry < CURRENT_TIMESTAMP(), 0) as expired, TRUE as legacy_password FROM passwords p JOIN users u ON u.userid = p.userid AND p.status = 'CURRENT' AND p.type <> 'bcrypt' WHERE u.username = ?;
           fieldPassword: password
           fieldDisabled: disabled
 #          fieldExpired: expired

--- a/src/main/resources/db/migration/R__02_stored_procedures.sql
+++ b/src/main/resources/db/migration/R__02_stored_procedures.sql
@@ -1,6 +1,6 @@
 DROP PROCEDURE IF EXISTS `sp_get_user_attributes`;
 DELIMITER //
-CREATE PROCEDURE `sp_get_user_attributes`(p_username varchar(255))
+CREATE PROCEDURE `sp_get_user_attributes`(p_username varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci)
   BEGIN
     SELECT 'email' AS 'key', email AS 'value' FROM users WHERE username=p_username
     UNION SELECT 'username' AS 'key', username AS 'value' FROM users WHERE username=p_username

--- a/src/test/kotlin/au/org/ala/cas/mysql/AbstractMysqlSqlIntegration.kt
+++ b/src/test/kotlin/au/org/ala/cas/mysql/AbstractMysqlSqlIntegration.kt
@@ -1,0 +1,195 @@
+package au.org.ala.cas.mysql
+
+import au.org.ala.cas.AlaCasProperties
+import au.org.ala.cas.delegated.UserCreatorALA
+import au.org.ala.cas.jdbc.AlaUserJdbcService
+import com.mysql.cj.jdbc.MysqlDataSource
+import org.flywaydb.core.Flyway
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.DataSourceTransactionManager
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.utility.DockerImageName
+import javax.sql.DataSource
+
+abstract class AbstractMysqlSqlIntegration(
+    private val mysqlVersion: String,
+    private val imageName: String
+) {
+
+    companion object {
+        private const val BCRYPT_AUTH_SQL = "SELECT p.password as password, not u.activated or u.locked as disabled, COALESCE(p.expiry < CURRENT_TIMESTAMP(), 0) as expired, FALSE as legacy_password FROM passwords p JOIN users u ON u.userid = p.userid AND p.status = 'CURRENT' AND p.type = 'bcrypt' WHERE u.username = ?;"
+        private const val LEGACY_AUTH_SQL = "SELECT p.password as password, not u.activated or u.locked as disabled, COALESCE(p.expiry < CURRENT_TIMESTAMP(), 0) as expired, TRUE as legacy_password FROM passwords p JOIN users u ON u.userid = p.userid AND p.status = 'CURRENT' AND p.type <> 'bcrypt' WHERE u.username = ?;"
+    }
+
+    @Test
+    fun `CAS SQL paths work against MySQL`() {
+        withMysql { dataSource, local ->
+            val jdbc = JdbcTemplate(dataSource)
+            val properties = AlaCasProperties()
+            val userJdbcService = AlaUserJdbcService(properties, dataSource, DataSourceTransactionManager(dataSource))
+
+            assertVersion(jdbc, local)
+            assertEquals(1, jdbc.queryForObject("/* ping */ SELECT 1", Int::class.java))
+            assertRoutineExists(jdbc, "sp_get_user_attributes")
+            assertRoutineExists(jdbc, "sp_create_user")
+
+            assertCasJdbcAuthenticationQueries(jdbc)
+            assertAttributeStoredProcedure(jdbc)
+            assertOverlayProfileAndPasswordService(jdbc, userJdbcService)
+            assertLastLoginServiceAndUserCreation(jdbc, userJdbcService, properties)
+        }
+    }
+
+    private fun withMysql(assertions: (DataSource, Boolean) -> Unit) {
+        val localJdbcUrl = System.getenv("CAS_MYSQL_TEST_URL") ?: System.getenv("CAS_MYSQL84_TEST_URL")
+        if (!localJdbcUrl.isNullOrBlank()) {
+            val dataSource = dataSource(
+                jdbcUrl = jdbcUrl(localJdbcUrl),
+                username = System.getenv("CAS_MYSQL_TEST_USER") ?: System.getenv("CAS_MYSQL84_TEST_USER") ?: "root",
+                password = System.getenv("CAS_MYSQL_TEST_PASSWORD") ?: System.getenv("CAS_MYSQL84_TEST_PASSWORD") ?: "password"
+            )
+            cleanAndMigrate(dataSource)
+            assertions(dataSource, true)
+            return
+        }
+
+        assumeTrue("Docker is required unless CAS_MYSQL_TEST_URL is set", DockerClientFactory.instance().isDockerAvailable)
+        val image = DockerImageName.parse(imageName).asCompatibleSubstituteFor("mysql")
+        val mysql = CasMysqlContainer(image)
+            .withDatabaseName("cas")
+            .withUsername("cas")
+            .withPassword("password")
+
+        mysql.start()
+        try {
+            val dataSource = dataSource(jdbcUrl(mysql.jdbcUrl), mysql.username, mysql.password)
+            cleanAndMigrate(dataSource)
+            assertions(dataSource, false)
+        } finally {
+            mysql.stop()
+        }
+    }
+
+    private fun cleanAndMigrate(dataSource: DataSource) {
+        Flyway.configure()
+            .dataSource(dataSource)
+            .locations("classpath:db/migration")
+            .cleanDisabled(false)
+            .load()
+            .run {
+                clean()
+                migrate()
+            }
+    }
+
+    private fun dataSource(jdbcUrl: String, username: String, password: String): DataSource = MysqlDataSource().apply {
+        setUrl(jdbcUrl)
+        user = username
+        this.password = password
+    }
+
+    private fun jdbcUrl(baseUrl: String): String {
+        val separator = if (baseUrl.contains('?')) '&' else '?'
+        return "${baseUrl}${separator}serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true&nullCatalogMeansCurrent=true&nullNamePatternMatchesAll=true"
+    }
+
+    private fun assertVersion(jdbc: JdbcTemplate, local: Boolean) {
+        val version = jdbc.queryForObject("SELECT VERSION()", String::class.java) ?: ""
+        if (!local) {
+            assertTrue("Expected MySQL $mysqlVersion but got $version", version.startsWith(mysqlVersion.substringBeforeLast('.')))
+        }
+    }
+
+    private fun assertRoutineExists(jdbc: JdbcTemplate, routineName: String) {
+        assertEquals(
+            1,
+            jdbc.queryForObject(
+                "SELECT COUNT(*) FROM information_schema.routines WHERE routine_schema = DATABASE() AND routine_name = ?",
+                Int::class.java,
+                routineName
+            )
+        )
+    }
+
+    private fun assertCasJdbcAuthenticationQueries(jdbc: JdbcTemplate) {
+        val username = "auth-${System.nanoTime()}@example.org"
+        val userid = createUser(jdbc, username)
+        jdbc.update("INSERT INTO passwords (userid, password, status, type) VALUES (?, ?, 'CURRENT', 'bcrypt')", userid, "bcrypt-hash")
+        jdbc.update("INSERT INTO passwords (userid, password, status, type) VALUES (?, ?, 'CURRENT', 'legacy')", userid, "legacy-hash")
+
+        val bcrypt = jdbc.queryForMap(BCRYPT_AUTH_SQL, username)
+        assertEquals("bcrypt-hash", bcrypt["password"])
+        assertFalse(asBoolean(bcrypt["disabled"]))
+        assertFalse(asBoolean(bcrypt["legacy_password"]))
+
+        val legacy = jdbc.queryForMap(LEGACY_AUTH_SQL, username)
+        assertEquals("legacy-hash", legacy["password"])
+        assertFalse(asBoolean(legacy["disabled"]))
+        assertTrue(asBoolean(legacy["legacy_password"]))
+    }
+
+    private fun assertAttributeStoredProcedure(jdbc: JdbcTemplate) {
+        val username = "attrs-${System.nanoTime()}@example.org"
+        val userid = createUser(jdbc, username)
+        jdbc.update("INSERT INTO user_role (user_id, role_id) VALUES (?, 'ROLE_USER')", userid)
+        jdbc.update("INSERT INTO profiles (userid, property, value) VALUES (?, 'organisation', 'ALA')", userid)
+
+        val attributes = jdbc.query("call sp_get_user_attributes(?)", { ps -> ps.setString(1, username) }) { rs, _ ->
+            rs.getString("key") to rs.getString("value")
+        }.toMap()
+
+        assertEquals(username, attributes["email"])
+        assertEquals(userid.toString(), attributes["userid"])
+        assertEquals("ROLE_USER", attributes["role"])
+        assertEquals("ALA", attributes["organisation"])
+    }
+
+    private fun assertOverlayProfileAndPasswordService(jdbc: JdbcTemplate, userJdbcService: AlaUserJdbcService) {
+        val userid = createUser(jdbc, "profile-${System.nanoTime()}@example.org")
+
+        assertTrue(userJdbcService.shouldOfferSurvey(userid))
+        assertEquals(1, userJdbcService.upsertProfile(userid, "affiliation", "community"))
+        assertFalse(userJdbcService.shouldOfferSurvey(userid))
+        assertEquals(1, userJdbcService.upsertProfile(userid, "affiliation", "education"))
+
+        userJdbcService.updateLegacyPassword(userid, "new-bcrypt-hash")
+
+        assertEquals("new-bcrypt-hash", jdbc.queryForObject("SELECT password FROM passwords WHERE userid = ? AND type = 'bcrypt' AND status = 'CURRENT'", String::class.java, userid))
+        assertEquals("education", jdbc.queryForObject("SELECT value FROM profiles WHERE userid = ? AND property = 'affiliation'", String::class.java, userid))
+    }
+
+    private fun assertLastLoginServiceAndUserCreation(jdbc: JdbcTemplate, userJdbcService: AlaUserJdbcService, properties: AlaCasProperties) {
+        val creator = UserCreatorALA(dataSource = jdbc.dataSource!!, createUserProcedure = properties.userCreator.jdbc.createUserProcedure, userCreatePassword = "password")
+        val userid = creator.createUser("created-${System.nanoTime()}@example.org", "Created", "User")
+        assertNotNull(userid)
+
+        assertEquals(1, userJdbcService.updateLastLogin(userid!!))
+        assertNotNull(jdbc.queryForObject("SELECT last_login FROM users WHERE userid = ?", java.sql.Timestamp::class.java, userid))
+        assertEquals("ROLE_USER", jdbc.queryForObject("SELECT role_id FROM user_role WHERE user_id = ?", String::class.java, userid))
+    }
+
+    private fun createUser(jdbc: JdbcTemplate, username: String): Long {
+        jdbc.update(
+            "INSERT INTO users (username, firstname, lastname, email, activated, locked) VALUES (?, 'Test', 'User', ?, '1', '0')",
+            username,
+            username
+        )
+        return jdbc.queryForObject("SELECT userid FROM users WHERE username = ?", Long::class.java, username)
+    }
+
+    private fun asBoolean(value: Any?): Boolean = when (value) {
+        is Boolean -> value
+        is Number -> value.toInt() != 0
+        is String -> value == "1" || value.equals("true", ignoreCase = true)
+        else -> false
+    }
+
+    private class CasMysqlContainer(image: DockerImageName) : MySQLContainer<CasMysqlContainer>(image)
+}

--- a/src/test/kotlin/au/org/ala/cas/mysql/Mysql57SqlIntegrationTest.kt
+++ b/src/test/kotlin/au/org/ala/cas/mysql/Mysql57SqlIntegrationTest.kt
@@ -1,0 +1,3 @@
+package au.org.ala.cas.mysql
+
+class Mysql57SqlIntegrationTest : AbstractMysqlSqlIntegration("5.7.44", "mysql:5.7.44")

--- a/src/test/kotlin/au/org/ala/cas/mysql/Mysql80SqlIntegrationTest.kt
+++ b/src/test/kotlin/au/org/ala/cas/mysql/Mysql80SqlIntegrationTest.kt
@@ -1,0 +1,3 @@
+package au.org.ala.cas.mysql
+
+class Mysql80SqlIntegrationTest : AbstractMysqlSqlIntegration("8.0.36", "mysql:8.0.36")

--- a/src/test/kotlin/au/org/ala/cas/mysql/Mysql84SqlIntegrationTest.kt
+++ b/src/test/kotlin/au/org/ala/cas/mysql/Mysql84SqlIntegrationTest.kt
@@ -1,0 +1,3 @@
+package au.org.ala.cas.mysql
+
+class Mysql84SqlIntegrationTest : AbstractMysqlSqlIntegration("8.4.0", "mysql:8.4.0")


### PR DESCRIPTION
 - Update stored proc to ensure param collation matches tables
 - Add unit tests that validate MySQL 5.7, 8.0 and 8.4 LTS
 - Refactor all custom db queries into AlaUserJdbcService
 - Update legacy password query to explicitly exclude bcrypt passwords